### PR TITLE
Allow integers and irrationals in Rotation angle

### DIFF
--- a/src/structs/Transitions.jl
+++ b/src/structs/Transitions.jl
@@ -31,9 +31,9 @@ anim_translate(x::Real, y::Real) = anim_translate(Point(x, y))
 anim_translate(tp::Point) = Translation(O, tp)
 anim_translate(fp::Union{Object,Point}, tp::Union{Object,Point}) = Translation(fp, tp)
 
-struct Rotation{T<:Real} <: AbstractTransition
-    from::T
-    to::T
+struct Rotation <: AbstractTransition
+    from::Real
+    to::Real
     center::Union{Nothing,Point,AbstractObject}
 end
 


### PR DESCRIPTION
An innocent user trying
    act!(object1, Action(anim_rotate_around(π, object2)))
will get a method error, because of the way Javis.Rotation is defined
using a parametric type. Same deal for
    anim_rotate[_around](o1, <integer>, o2)
The small change in the definition of Rotation in this commit allows
the use of Irrational and Integer angles in anim_rotate_around()
and anim_rotate().

## PR Checklist

If you are contributing to `Javis.jl`, please make sure you are able to check off each item on this list:

- [ ] Did I update `CHANGELOG.md` with whatever changes/features I added with this PR?
- [ ] Did I make sure to only change the part of the file where I introduced a new change/feature?
- [ ] Did I cover all corner cases to be close to 100% test coverage (if applicable)?
- [ ] Did I properly add Javis dependencies to the `Project.toml` + set an upper bound of the dependency (if applicable)?
- [ ] Did I properly add test dependencies to the `test` directory (if applicable)?
- [ ] Did I check relevant tutorials that may be affected by changes in this PR?
- [ ] Did I clearly articulate why this PR was made the way it was and how it was made?

**Link to relevant issue(s)**
Closes #


**How did you address these issues with this PR? What methods did you use?**



