### PR TITLE
add LatexString overload, add test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Javis.jl - Changelog
 
-##for PR
+##for PR-
+- add overload for keyword arguments to latex() function
 - change font scaling in svg2luxor from 1/2 to 425/1000
 - change default line width to 2.0 like luxor 
 

--- a/src/latex.jl
+++ b/src/latex.jl
@@ -8,6 +8,9 @@ latex(text::LaTeXString, pos::Point, valign::Symbol, halign::Symbol) =
 latex(text::LaTeXString, x, y) = latex(text, Point(x, y), :stroke)
 latex(text::LaTeXString, x, y, valign::Symbol, halign::Symbol) =
     latex(text, Point(x, y), :stroke, valign = valign, halign = halign)
+latex(text::LaTeXString, pos::Point; valign=:top, halign=:left) =
+    latex(text, pos, :stroke, valign = valign, halign = halign)
+
 """
     latex(text::LaTeXString, pos::Point, object::Symbol; valign = :top, halign = :left)
 

--- a/src/latex.jl
+++ b/src/latex.jl
@@ -8,7 +8,7 @@ latex(text::LaTeXString, pos::Point, valign::Symbol, halign::Symbol) =
 latex(text::LaTeXString, x, y) = latex(text, Point(x, y), :stroke)
 latex(text::LaTeXString, x, y, valign::Symbol, halign::Symbol) =
     latex(text, Point(x, y), :stroke, valign = valign, halign = halign)
-latex(text::LaTeXString, pos::Point; valign=:top, halign=:left) =
+latex(text::LaTeXString, pos::Point; valign = :top, halign = :left) =
     latex(text, pos, :stroke, valign = valign, halign = halign)
 
 """

--- a/test/svg.jl
+++ b/test/svg.jl
@@ -54,7 +54,7 @@ end
     Object((args...) -> latex(L"8", O + Point(20, 20), :bottom, :right))
     Object((args...) -> latex(L"8", O + Point(20, 20), :bottom, :left))
     Object((args...) -> latex(L"8", O + Point(20, 20), :top, :right))
-    Object((args...) -> latex(L"8", O + Point(20, 20), valign=:top, halign=:right))
+    Object((args...) -> latex(L"8", O + Point(20, 20), valign = :top, halign = :right))
 
     # testing for warn log message on passing incorrect input alignment parameters (default used)
     Object((args...) -> latex(L"8", O + Point(20, 20), :left, :top))

--- a/test/svg.jl
+++ b/test/svg.jl
@@ -54,6 +54,7 @@ end
     Object((args...) -> latex(L"8", O + Point(20, 20), :bottom, :right))
     Object((args...) -> latex(L"8", O + Point(20, 20), :bottom, :left))
     Object((args...) -> latex(L"8", O + Point(20, 20), :top, :right))
+    Object((args...) -> latex(L"8", O + Point(20, 20), valign=:top, halign=:right))
 
     # testing for warn log message on passing incorrect input alignment parameters (default used)
     Object((args...) -> latex(L"8", O + Point(20, 20), :left, :top))

--- a/test/svg.jl
+++ b/test/svg.jl
@@ -53,7 +53,6 @@ end
     Background(1:1, latex_ground)
     Object((args...) -> latex(L"8", O + Point(20, 20), :bottom, :right))
     Object((args...) -> latex(L"8", O + Point(20, 20), :bottom, :left))
-    Object((args...) -> latex(L"8", O + Point(20, 20), :top, :right))
     Object((args...) -> latex(L"8", O + Point(20, 20), valign = :top, halign = :right))
 
     # testing for warn log message on passing incorrect input alignment parameters (default used)


### PR DESCRIPTION
Closes #474.

After some discussion in the Javis.jl Zulip chat, I added an overload for the `latex` function with `valign` defaulting to `:top` and `halign` defaulting to `:left`.

A single regression test was added in `svg.jl` to make sure that this overload was working correctly.
