### PR TITLE
Wait for ffmpeg to exit after close

### DIFF
--- a/src/Javis.jl
+++ b/src/Javis.jl
@@ -359,6 +359,7 @@ function render(
         )
     elseif ext == ".mp4"
         close(ffmpegproc)
+        wait(ffmpegproc)
     else
         @error "Currently, only gif and mp4 creation is supported. Not a $ext."
     end


### PR DESCRIPTION

small change ,
added wait for ffmpegproc (to exit) after we close it ,
Not a major issue but this ensures the .mp4 exists after render is done.

A problem arises if one is going to play the video or further do some other processing on it from the script immediately after render .
